### PR TITLE
Update tag feature

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -34,6 +34,9 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered person list with Goods Categories Tags Added **/
+    ObservableList<Person> getObservableFilteredPersonsWithGoodsCategoryTagsAdded();
+
     /**
      * Returns a list of filtered goods receipts.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -74,6 +74,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public ObservableList<Person> getObservableFilteredPersonsWithGoodsCategoryTagsAdded() {
+        return model.getObservableFilteredPersonsWithGoodsCategoryTagsAdded();
+    }
+
+    @Override
     public ObservableList<GoodsReceipt> getFilteredReceiptsList() {
         return model.getFilteredReceiptsList();
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -82,6 +82,9 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered person list with Goods Categories Tags Added **/
+    ObservableList<Person> getObservableFilteredPersonsWithGoodsCategoryTagsAdded();
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -68,6 +69,15 @@ public class Person {
     }
 
     /**
+     * Returns a new person with added tags.
+     */
+    public Person addTags(Collection<Tag> addTags) {
+        HashSet<Tag> newTags = new HashSet<>(tags);
+        newTags.addAll(addTags);
+        return new Person(name, phone, address, newTags);
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
@@ -104,5 +114,4 @@ public class Person {
                 .add("tags", tags)
                 .toString();
     }
-
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -115,7 +115,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getObservableFilteredPersonsWithGoodsCategoryTagsAdded());
         personGoodsSplitPanePlaceholder.getItems().add(personListPanel.getRoot());
 
         goodsListPanel = new GoodsListPanel(logic.getFilteredReceiptsList());

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -159,6 +159,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Person> getObservableFilteredPersonsWithGoodsCategoryTagsAdded() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -13,15 +13,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.goods.Goods;
+import seedu.address.model.goods.GoodsCategories;
 import seedu.address.model.goods.GoodsName;
 import seedu.address.model.goodsreceipt.GoodsReceipt;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.GoodsBuilder;
 import seedu.address.testutil.GoodsReceiptBuilder;
@@ -181,6 +188,38 @@ public class ModelManagerTest {
     @Test
     public void getFilteredGoods() {
         // TODO: Implement this
+    }
+
+    @Test
+    public void getFilteredPersonsWithGoodsCategoryTagsAdded() {
+        modelManager.addPerson(ALICE);
+        Goods apple = new GoodsBuilder()
+                .withName("Apple")
+                .withGoodsCategory(GoodsCategories.SPECIALTY)
+                .build();
+        Goods banana = new GoodsBuilder()
+                .withName("Banana")
+                .withGoodsCategory(GoodsCategories.CONSUMABLES)
+                .build();
+        GoodsReceipt appleReceipt = new GoodsReceiptBuilder()
+                .withSupplierName(ALICE.getName())
+                .withGoods(apple)
+                .build();
+        GoodsReceipt bananaReceipt = new GoodsReceiptBuilder()
+                .withSupplierName(ALICE.getName())
+                .withGoods(banana)
+                .build();
+        modelManager.addGoods(appleReceipt);
+        modelManager.addGoods(bananaReceipt);
+        modelManager.updateFilteredPersonList(p -> p.equals(ALICE));
+        Person alice = modelManager
+                .getObservableFilteredPersonsWithGoodsCategoryTagsAdded()
+                .stream().findAny().get();
+        Set<Tag> expectedTags = Stream
+                .of(ALICE.getTags(), List.of(new Tag("SPECIALTY"), new Tag("CONSUMABLES")))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+        assertEquals(alice.getTags(), expectedTags);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -11,8 +11,15 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
@@ -48,6 +55,20 @@ public class PersonTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSamePerson(editedBob));
+    }
+
+    @Test
+    public void addTags() {
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+        List<Tag> addTags = List.of(new Tag("Hello"), new Tag("World"));
+        Person newAlice = ALICE.addTags(addTags);
+        Set<Tag> expectedTags = Stream
+                .of(ALICE.getTags(), addTags)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        assertEquals(ALICE, aliceCopy);
+        assertEquals(newAlice.getTags(), expectedTags);
     }
 
     @Test


### PR DESCRIPTION
Resolves #118. Updated supplier tags to also contain the goods categories of their supplied goods (receipts). The existing tag feature remains as it is.