### PR TITLE
Raise error if Preamble is given with viewgoods

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ListGoodsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListGoodsCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ListGoodsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.goods.GoodsCategories;
@@ -37,6 +38,11 @@ public class ListGoodsCommandParser implements Parser<ListGoodsCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CATEGORY, PREFIX_GOODS_NAME, PREFIX_NAME);
         Predicate<GoodsReceipt> predicate = null;
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(
+                    Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListGoodsCommand.MESSAGE_USAGE));
+        }
 
         // check for the three optional inputs and chain if needed
         if (arePrefixesPresent(argMultimap, PREFIX_GOODS_NAME)) {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -96,7 +96,6 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_listGoods() throws Exception {
         assertTrue(parser.parseCommand(ListGoodsCommand.COMMAND_WORD) instanceof ListGoodsCommand);
-        assertTrue(parser.parseCommand(ListGoodsCommand.COMMAND_WORD + " 3") instanceof ListGoodsCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListGoodsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListGoodsCommandParserTest.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ListGoodsCommand;
 import seedu.address.model.goods.GoodsCategories;
 import seedu.address.model.goodsreceipt.CategoryPredicate;
@@ -24,26 +25,32 @@ public class ListGoodsCommandParserTest {
     public void parse_validArgs_returnsListGoodsCommand() {
         // Valid input with only category keyword args
         ListGoodsCommand expectedListGoodsCommand = new ListGoodsCommand(categoryPredicate);
-        assertParseSuccess(parser, "viewgoods c/CONSUMABLES", expectedListGoodsCommand);
+        assertParseSuccess(parser, " c/CONSUMABLES", expectedListGoodsCommand);
 
         // Valid input with only goodsName keyword args
         ListGoodsCommand expectedListGoodsCommand2 = new ListGoodsCommand(goodsNamePredicate);
-        assertParseSuccess(parser, "viewgoods gn/bread", expectedListGoodsCommand2);
+        assertParseSuccess(parser, " gn/bread", expectedListGoodsCommand2);
 
         // Valid input with composed filters
-        assertDoesNotThrow(() -> parser.parse("viewgoods gn/bread c/CONSUMABLES"));
+        assertDoesNotThrow(() -> parser.parse(" gn/bread c/CONSUMABLES"));
     }
 
     @Test
     public void parse_invalidArgs_failure() {
         // Invalid input for category keyword
-        assertParseFailure(parser, "viewgoods c/NOTHING", GoodsCategories.MESSAGE_UNKNOWN_CATEGORY);
+        assertParseFailure(parser, " c/NOTHING", GoodsCategories.MESSAGE_UNKNOWN_CATEGORY);
     }
 
     @Test
     public void parse_noArgs_returnListGoodsCommand() {
         // Valid input with no args
         ListGoodsCommand expectedListGoodsCommand = new ListGoodsCommand(dummyPredicate);
-        assertParseSuccess(parser, "viewgoods", expectedListGoodsCommand);
+        assertParseSuccess(parser, "", expectedListGoodsCommand);
+    }
+
+    @Test
+    public void parse_preambleIncluded_failure() {
+        assertParseFailure(parser, "pre",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ListGoodsCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
As per intended usage in UG, `viewgoods` should only accept prefixed parameters or none at all.

Preamble should result in an error as documented, instead of silently returning the same effect as `viewgoods`.