### PR TITLE
Goods delete fix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
@@ -13,8 +13,6 @@ import seedu.address.model.goods.GoodsName;
 import seedu.address.model.goodsreceipt.GoodsReceipt;
 import seedu.address.model.person.Name;
 
-
-
 /**
  * Deletes the goods receipt that belongs to a supplier.
  */

--- a/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
@@ -7,9 +7,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.goods.Goods;
 import seedu.address.model.goods.GoodsName;
 import seedu.address.model.goodsreceipt.GoodsReceipt;
 import seedu.address.model.person.Name;
+
+import java.util.List;
 
 /**
  * Deletes the goods receipt that belongs to a supplier.
@@ -45,12 +48,18 @@ public class DeleteGoodsCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        GoodsReceipt receipt = model
-                .findGoodsReceipt(
-                        r -> (r.isFromSupplier(supplierName)
-                                && r.getGoods().goodsName().equals(goodsName)))
-                .orElseThrow(() -> new CommandException(Messages.MESSAGE_GOODS_RECEIPT_NOT_FOUND));
-        model.deleteGoods(receipt);
+
+        List<GoodsReceipt> receiptList =
+                model.findGoodsReceipts(
+                        r -> (r.isFromSupplier(supplierName) && r.getGoods().goodsName().equals(goodsName)));
+
+        if (receiptList.isEmpty()) {
+            throw new CommandException(Messages.MESSAGE_GOODS_RECEIPT_NOT_FOUND);
+        }
+
+        for (GoodsReceipt receipt : receiptList) {
+            model.deleteGoods(receipt);
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, goodsName));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGoodsCommand.java
@@ -4,15 +4,16 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GOODS_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.List;
+
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.goods.Goods;
 import seedu.address.model.goods.GoodsName;
 import seedu.address.model.goodsreceipt.GoodsReceipt;
 import seedu.address.model.person.Name;
 
-import java.util.List;
+
 
 /**
  * Deletes the goods receipt that belongs to a supplier.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -161,6 +161,8 @@ public interface Model {
      */
     void updateFilteredReceiptsList(Predicate<GoodsReceipt> predicate);
 
+    List<GoodsReceipt> findGoodsReceipts(Predicate<GoodsReceipt> predicate);
+
     /**
      * Returns the total quantity of the filtered goods list.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -303,6 +303,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public List<GoodsReceipt> findGoodsReceipts(Predicate<GoodsReceipt> predicate) {
+        return this.goodsList.getReceiptList().stream().filter(predicate).toList();
+    }
+
+    @Override
     public int getFilteredGoodsQuantityStatistics() {
         return GoodsReceiptUtil.sumQuantity(filteredReceipts);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -234,6 +234,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public List<GoodsReceipt> findGoodsReceipts(Predicate<GoodsReceipt> predicate) {
+            return null;
+        }
+
+        @Override
         public List<GoodsReceipt> getFilteredGoods(Predicate<GoodsReceipt> predicate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/DeleteGoodsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGoodsCommandTest.java
@@ -82,4 +82,31 @@ public class DeleteGoodsCommandTest {
         expectedModel.addPerson(ALICE);
         assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
     }
+
+    @Test
+    public void execute_existingSupplierNameAndMultipleExistingGoodsName_success() {
+        ModelManager model = new ModelManager();
+        model.addPerson(ALICE);
+        Goods apple = new GoodsBuilder()
+                .withName("Apple")
+                .withGoodsCategory(GoodsCategories.CONSUMABLES)
+                .build();
+        GoodsReceipt appleReceipt = new GoodsReceiptBuilder()
+                .withSupplierName(ALICE.getName())
+                .withGoods(apple)
+                .build();
+        GoodsReceipt appleReceipt2 = new GoodsReceiptBuilder()
+                .withSupplierName(ALICE.getName())
+                .withQuantity(5)
+                .withGoods(apple)
+                .build();
+        model.addGoods(appleReceipt);
+        model.addGoods(appleReceipt2);
+
+        DeleteGoodsCommand cmd = new DeleteGoodsCommand(ALICE.getName(), apple.goodsName());
+        String expectedMessage = String.format(MESSAGE_SUCCESS, apple.goodsName());
+        ModelManager expectedModel = new ModelManager();
+        expectedModel.addPerson(ALICE);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGoodsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGoodsCommandTest.java
@@ -93,6 +93,7 @@ public class DeleteGoodsCommandTest {
                 .build();
         GoodsReceipt appleReceipt = new GoodsReceiptBuilder()
                 .withSupplierName(ALICE.getName())
+                .withQuantity(6)
                 .withGoods(apple)
                 .build();
         GoodsReceipt appleReceipt2 = new GoodsReceiptBuilder()


### PR DESCRIPTION
Prev logic: Finds one random goodsReceipt and deletes it  
Updated logic: Deletes **all goods** that have the same name based on the supplier name provided


Logic can be modified due to this specification in the User Guide:


![image](https://github.com/user-attachments/assets/09195e00-1b3e-43e6-9149-5a26a9f7ab68)